### PR TITLE
Add Header Support

### DIFF
--- a/greedo-layout/src/main/java/com/fivehundredpx/greedolayout/GreedoLayoutManager.java
+++ b/greedo-layout/src/main/java/com/fivehundredpx/greedolayout/GreedoLayoutManager.java
@@ -263,8 +263,32 @@ public class GreedoLayoutManager extends RecyclerView.LayoutManager {
         );
     }
 
+    /**
+     * Returns the adapter position of the first visible view.
+     *
+     * @return The adapter position of the first visible view or {@link RecyclerView#NO_POSITION} if
+     * there aren't any visible items.
+     */
     public int findFirstVisibleItemPosition() {
-        return mFirstVisiblePosition;
+        if (getItemCount() == 0) {
+            return RecyclerView.NO_POSITION;
+        } else {
+            return mFirstVisiblePosition;
+        }
+    }
+
+    /**
+     * Returns the adapter position of the last visible view.
+     *
+     * @return The adapter position of the last visible view or {@link RecyclerView#NO_POSITION} if
+     * there aren't any visible items.
+     */
+    public int findLastVisibleItemPosition() {
+        if (getItemCount() == 0) {
+            return RecyclerView.NO_POSITION;
+        } else {
+            return mFirstVisiblePosition + getChildCount();
+        }
     }
 
     public GreedoLayoutSizeCalculator getSizeCalculator() {

--- a/greedo-layout/src/main/java/com/fivehundredpx/greedolayout/GreedoLayoutManager.java
+++ b/greedo-layout/src/main/java/com/fivehundredpx/greedolayout/GreedoLayoutManager.java
@@ -12,9 +12,12 @@ import com.fivehundredpx.greedolayout.GreedoLayoutSizeCalculator.SizeCalculatorD
  * Created by Julian Villella on 15-08-24.
  */
 
+// TODO: When measuring children we can likely pass getContentWidth() as their widthUsed
+
 public class GreedoLayoutManager extends RecyclerView.LayoutManager {
     private static final String TAG = GreedoLayoutManager.class.getSimpleName();
 
+    // TODO: Can we do away with this?
     private enum Direction { NONE, UP, DOWN }
 
     // First (top-left) position visible at any point
@@ -225,23 +228,35 @@ public class GreedoLayoutManager extends RecyclerView.LayoutManager {
         final View topLeftView = getChildAt(0);
         final View bottomRightView = getChildAt(getChildCount() - 1);
         int pixelsFilled = getContentHeight();
+        // TODO: Split into methods, or a switch case?
         if (dy > 0) {
-            boolean lastChildIsVisible = mFirstVisiblePosition + getChildCount() >= getItemCount();
-            if (lastChildIsVisible && pixelsFilled <= getContentHeight()) { // is at end of content
-                pixelsFilled = Math.max(getDecoratedBottom(getChildAt(getChildCount() - 1)) - getContentHeight(), 0);
-            } else if (getDecoratedBottom(topLeftView) - dy <= 0) { // top row went offscreen
+            boolean isLastChildVisible = (mFirstVisiblePosition + getChildCount()) >= getItemCount();
+
+            if (isLastChildVisible) {
+                // Is at end of content
+                pixelsFilled = Math.max(getDecoratedBottom(bottomRightView) - getContentHeight(), 0);
+
+            } else if (getDecoratedBottom(topLeftView) - dy <= 0) {
+                // Top row went offscreen
                 mFirstVisibleRow++;
                 pixelsFilled = preFillGrid(Direction.DOWN, Math.abs(dy), 0, recycler, state);
-            } else if (getDecoratedBottom(bottomRightView) - dy < getContentHeight()) { // new bottom row came on screen
+
+            } else if (getDecoratedBottom(bottomRightView) - dy < getContentHeight()) {
+                // New bottom row came on screen
                 pixelsFilled = preFillGrid(Direction.DOWN, Math.abs(dy), 0, recycler, state);
             }
         } else {
-            if (mFirstVisibleRow == 0 && getDecoratedTop(topLeftView) - dy >= 0) { // is scrolled to top
+            if (mFirstVisibleRow == 0 && getDecoratedTop(topLeftView) - dy >= 0) {
+                // Is scrolled to top
                 pixelsFilled = -getDecoratedTop(topLeftView);
-            } else if (getDecoratedTop(topLeftView) - dy >= 0) { // new top row came on screen
+
+            } else if (getDecoratedTop(topLeftView) - dy >= 0) {
+                // New top row came on screen
                 mFirstVisibleRow--;
                 pixelsFilled = preFillGrid(Direction.UP, Math.abs(dy), 0, recycler, state);
-            } else if (getDecoratedTop(bottomRightView) - dy > getContentHeight()) { // bottom row went offscreen
+
+            } else if (getDecoratedTop(bottomRightView) - dy > getContentHeight()) {
+                // Bottom row went offscreen
                 pixelsFilled = preFillGrid(Direction.UP, Math.abs(dy), 0, recycler, state);
             }
         }
@@ -249,9 +264,9 @@ public class GreedoLayoutManager extends RecyclerView.LayoutManager {
         final int scrolled = Math.abs(dy) > pixelsFilled ? (int)Math.signum(dy) * pixelsFilled : dy;
         offsetChildrenVertical(-scrolled);
 
-        // Return value determines if a boundary has been reached (for edge effects and flings).
-        // If returned value does not match original delta (passed in), RecyclerView will draw
-        // an edge effect.
+        // Return value determines if a boundary has been reached (for edge effects and flings). If
+        //      returned value does not match original delta (passed in), RecyclerView will draw an
+        //      edge effect.
         return scrolled;
     }
 

--- a/greedo-layout/src/main/java/com/fivehundredpx/greedolayout/GreedoLayoutManager.java
+++ b/greedo-layout/src/main/java/com/fivehundredpx/greedolayout/GreedoLayoutManager.java
@@ -276,6 +276,9 @@ public class GreedoLayoutManager extends RecyclerView.LayoutManager {
     }
     //endregion
 
+    /**
+     * {@inheritDoc}
+     */
     @Override
     public void scrollToPosition(int position) {
         if (position >= getItemCount()) {
@@ -289,6 +292,16 @@ public class GreedoLayoutManager extends RecyclerView.LayoutManager {
         requestLayout();
     }
 
+    /**
+     * Scroll to the specified adapter position with the given offset. Note that the scroll position
+     * change will not be reflected until the next layout call. If you are just trying to make a
+     * position visible, use {@link #scrollToPosition(int)}.
+     *
+     * @param position Index (starting at 0) of the reference item.
+     * @param offset   The distance (in pixels) between the start edge of the item view and
+     *                 start edge of the RecyclerView.
+     * @see #scrollToPosition(int)
+     */
     public void scrollToPositionWithOffset(int position, int offset) {
         mPendingScrollPositionOffset = offset;
         scrollToPosition(position);

--- a/greedo-layout/src/main/java/com/fivehundredpx/greedolayout/GreedoSpacingItemDecoration.java
+++ b/greedo-layout/src/main/java/com/fivehundredpx/greedolayout/GreedoSpacingItemDecoration.java
@@ -8,6 +8,8 @@ import android.view.View;
  * Created by Julian Villella on 15-07-30.
  */
 public class GreedoSpacingItemDecoration extends RecyclerView.ItemDecoration {
+    private static final String TAG = GreedoSpacingItemDecoration.class.getName();
+
     public static int DEFAULT_SPACING = 64;
     private int mSpacing;
 
@@ -23,32 +25,53 @@ public class GreedoSpacingItemDecoration extends RecyclerView.ItemDecoration {
     public void getItemOffsets(Rect outRect, View view, RecyclerView parent, RecyclerView.State state) {
         if (!(parent.getLayoutManager() instanceof GreedoLayoutManager)) {
             throw new IllegalArgumentException(String.format("The %s must be used with a %s",
-                    GreedoSpacingItemDecoration.class.getSimpleName(), GreedoLayoutManager.class.getSimpleName()));
+                    GreedoSpacingItemDecoration.class.getSimpleName(),
+                    GreedoLayoutManager.class.getSimpleName()));
         }
 
-        int childIndex = parent.getChildAdapterPosition(view);
+        final GreedoLayoutManager layoutManager = (GreedoLayoutManager) parent.getLayoutManager();
 
-        GreedoLayoutManager layoutManager = (GreedoLayoutManager) parent.getLayoutManager();
-        GreedoLayoutSizeCalculator sizeCalculator = layoutManager.getSizeCalculator();
+        int childIndex = parent.getChildAdapterPosition(view);
+        if (childIndex == RecyclerView.NO_POSITION) return;
 
         outRect.top    = 0;
         outRect.bottom = mSpacing;
         outRect.left   = 0;
         outRect.right  = mSpacing;
 
-        // Add inter-item spacings (don't add spacings on edges)
-        if (isTopChild(childIndex, sizeCalculator))
+        // Add inter-item spacings
+        if (isTopChild(childIndex, layoutManager)) {
             outRect.top = mSpacing;
+        }
 
-        if (isLeftChild(childIndex, sizeCalculator))
+        if (isLeftChild(childIndex, layoutManager)) {
             outRect.left = mSpacing;
+        }
     }
 
-    private boolean isTopChild(int position, GreedoLayoutSizeCalculator sizeCalculator) {
+    private static boolean isTopChild(int position, GreedoLayoutManager layoutManager) {
+        boolean isFirstViewHeader = layoutManager.isFirstViewHeader();
+        if (isFirstViewHeader && position == GreedoLayoutManager.HEADER_POSITION) {
+            return true;
+        } else if (isFirstViewHeader && position > GreedoLayoutManager.HEADER_POSITION) {
+            // Decrement position to factor in existence of header
+            position -= 1;
+        }
+
+        final GreedoLayoutSizeCalculator sizeCalculator = layoutManager.getSizeCalculator();
         return sizeCalculator.getRowForChildPosition(position) == 0;
     }
 
-    private boolean isLeftChild(int position, GreedoLayoutSizeCalculator sizeCalculator) {
+    private static boolean isLeftChild(int position, GreedoLayoutManager layoutManager) {
+        boolean isFirstViewHeader = layoutManager.isFirstViewHeader();
+        if (isFirstViewHeader && position == GreedoLayoutManager.HEADER_POSITION) {
+            return true;
+        } else if (isFirstViewHeader && position > GreedoLayoutManager.HEADER_POSITION) {
+            // Decrement position to factor in existence of header
+            position -= 1;
+        }
+
+        final GreedoLayoutSizeCalculator sizeCalculator = layoutManager.getSizeCalculator();
         int rowForPosition = sizeCalculator.getRowForChildPosition(position);
         return sizeCalculator.getFirstChildPositionForRow(rowForPosition) == position;
     }


### PR DESCRIPTION
This PR adds support for a top header view which will not be laid out according to the full aspect-ratio grid, but instead, its specific measured view size. In addition to this, there are few more new public methods being added in this PR. Namely,

```
public void scrollToPositionWithOffset(int position, int offset);
```
_Scroll to the specified adapter position with the given offset. Note that the scroll position change will not be reflected until the next layout call. If you are just trying to make a position visible, use {@link #scrollToPosition(int)}._

and,

```
public int findLastVisibleItemPosition();
```
_Returns the adapter position of the last visible view._