### PR TITLE
Add support for fixed height rows

### DIFF
--- a/greedo-layout-sample/src/main/java/com/fivehundredpx/greedo_layout_sample/PhotosAdapter.java
+++ b/greedo-layout-sample/src/main/java/com/fivehundredpx/greedo_layout_sample/PhotosAdapter.java
@@ -43,7 +43,7 @@ public class PhotosAdapter extends RecyclerView.Adapter<PhotosAdapter.PhotoViewH
     @Override
     public PhotoViewHolder onCreateViewHolder(ViewGroup parent, int viewType) {
         ImageView imageView = new ImageView(mContext);
-        imageView.setScaleType(ImageView.ScaleType.FIT_XY);
+        imageView.setScaleType(ImageView.ScaleType.CENTER_CROP);
 
         imageView.setLayoutParams(new ViewGroup.LayoutParams(
                 ViewGroup.LayoutParams.MATCH_PARENT,
@@ -56,7 +56,6 @@ public class PhotosAdapter extends RecyclerView.Adapter<PhotosAdapter.PhotoViewH
     public void onBindViewHolder(PhotoViewHolder holder, int position) {
         Picasso.with(mContext)
                 .load(mImageResIds[getLoopedIndex(position)])
-                .fit()
                 .into(holder.mImageView);
     }
 

--- a/greedo-layout-sample/src/main/java/com/fivehundredpx/greedo_layout_sample/SampleActivity.java
+++ b/greedo-layout-sample/src/main/java/com/fivehundredpx/greedo_layout_sample/SampleActivity.java
@@ -1,9 +1,14 @@
 package com.fivehundredpx.greedo_layout_sample;
 
+import android.os.Build;
 import android.os.Bundle;
 import android.support.v7.app.AppCompatActivity;
 import android.support.v7.widget.RecyclerView;
 import android.util.DisplayMetrics;
+import android.view.View;
+import android.view.Window;
+import android.view.WindowManager;
+import android.widget.ToggleButton;
 
 import com.fivehundredpx.greedolayout.GreedoLayoutManager;
 import com.fivehundredpx.greedolayout.GreedoSpacingItemDecoration;
@@ -18,18 +23,28 @@ public class SampleActivity extends AppCompatActivity {
         super.onCreate(savedInstanceState);
         setContentView(R.layout.activity_sample);
 
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.KITKAT) {
+            getWindow().setFlags(WindowManager.LayoutParams.FLAG_TRANSLUCENT_STATUS,
+                    WindowManager.LayoutParams.FLAG_TRANSLUCENT_STATUS);
+        }
+
         PhotosAdapter photosAdapter = new PhotosAdapter(this);
-        GreedoLayoutManager layoutManager = new GreedoLayoutManager(photosAdapter);
+        final GreedoLayoutManager layoutManager = new GreedoLayoutManager(photosAdapter);
+        layoutManager.setMaxRowHeight(MeasUtils.dpToPx(150, this));
 
         RecyclerView recyclerView = (RecyclerView)findViewById(R.id.recycler_view);
         recyclerView.setLayoutManager(layoutManager);
         recyclerView.setAdapter(photosAdapter);
 
-        DisplayMetrics metrics = getResources().getDisplayMetrics();
-        int maxRowHeight = metrics.heightPixels / 3;
-        layoutManager.setMaxRowHeight(maxRowHeight);
-
         int spacing = MeasUtils.dpToPx(4, this);
         recyclerView.addItemDecoration(new GreedoSpacingItemDecoration(spacing));
+
+        findViewById(R.id.toggle_fixed_height).setOnClickListener(new View.OnClickListener() {
+            @Override
+            public void onClick(View view) {
+                layoutManager.setFixedHeight(((ToggleButton) view).isChecked());
+                layoutManager.requestLayout();
+            }
+        });
     }
 }

--- a/greedo-layout-sample/src/main/res/layout/activity_sample.xml
+++ b/greedo-layout-sample/src/main/res/layout/activity_sample.xml
@@ -1,5 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
-<RelativeLayout xmlns:android="http://schemas.android.com/apk/res/android"
+<RelativeLayout
+    xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:tools="http://schemas.android.com/tools"
     android:layout_width="match_parent"
     android:layout_height="match_parent"
@@ -9,5 +10,15 @@
         android:id="@+id/recycler_view"
         android:layout_width="match_parent"
         android:layout_height="match_parent" />
+
+    <ToggleButton
+        android:id="@+id/toggle_fixed_height"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_alignParentBottom="true"
+        android:layout_centerHorizontal="true"
+        android:layout_margin="8dp"
+        android:textOff="@string/enable_fixed_height"
+        android:textOn="@string/disable_fixed_height" />
 
 </RelativeLayout>

--- a/greedo-layout-sample/src/main/res/values/strings.xml
+++ b/greedo-layout-sample/src/main/res/values/strings.xml
@@ -1,3 +1,5 @@
 <resources>
     <string name="app_name">Greedo Layout</string>
+    <string name="enable_fixed_height">Enable Fixed Height</string>
+    <string name="disable_fixed_height">Disable Fixed Height</string>
 </resources>

--- a/greedo-layout/src/main/java/com/fivehundredpx/greedolayout/GreedoLayoutManager.java
+++ b/greedo-layout/src/main/java/com/fivehundredpx/greedolayout/GreedoLayoutManager.java
@@ -36,9 +36,9 @@ public class GreedoLayoutManager extends RecyclerView.LayoutManager {
     private int mPendingScrollPositionOffset = 0;
 
     // Flag to indicate that the first item should be treated as a header. Note: The size calculator
-    //      doesn't factor in the existence of a header. That is left to the layout manager. This
-    //      also means, that the positions used to query the size calculator should be offset by -1
-    //      if we are using a header.
+    // doesn't factor in the existence of a header. That is left to the layout manager. This also
+    // means, that the positions used to query the size calculator should be offset by -1 if we are
+    // using a header.
     private boolean mIsFirstViewHeader;
 
     // The size of the header view. This is calculated in {@code preFillGrid}.
@@ -50,6 +50,22 @@ public class GreedoLayoutManager extends RecyclerView.LayoutManager {
         mSizeCalculator = new GreedoLayoutSizeCalculator(sizeCalculatorDelegate);
     }
 
+    /**
+     * Set to true if you want all rows to be of the same height. The height will be equal to the
+     * value passed to {@code setMaxRowHeight(int)}.
+     *
+     * @param fixedHeight true to ensure all rows will have the same height.
+     */
+    public void setFixedHeight(boolean fixedHeight) {
+        mSizeCalculator.setFixedHeight(fixedHeight);
+    }
+
+    /**
+     * The max height a row could be. If fixed height is enabled via {@code setFixedHeight(boolean)}
+     * the given max row height value will be used as the fixed row height.
+     *
+     * @param maxRowHeight Max height a row can grow to.
+     */
     public void setMaxRowHeight(int maxRowHeight) {
         mSizeCalculator.setMaxRowHeight(maxRowHeight);
     }

--- a/greedo-layout/src/main/java/com/fivehundredpx/greedolayout/GreedoLayoutManager.java
+++ b/greedo-layout/src/main/java/com/fivehundredpx/greedolayout/GreedoLayoutManager.java
@@ -370,7 +370,7 @@ public class GreedoLayoutManager extends RecyclerView.LayoutManager {
             }
         }
 
-        final int scrolled = Math.abs(dy) > pixelsFilled ? (int)Math.signum(dy) * pixelsFilled : dy;
+        final int scrolled = Math.abs(dy) > pixelsFilled ? (int) Math.signum(dy) * pixelsFilled : dy;
         offsetChildrenVertical(-scrolled);
 
         // Return value determines if a boundary has been reached (for edge effects and flings). If

--- a/greedo-layout/src/main/java/com/fivehundredpx/greedolayout/GreedoLayoutSizeCalculator.java
+++ b/greedo-layout/src/main/java/com/fivehundredpx/greedolayout/GreedoLayoutSizeCalculator.java
@@ -59,7 +59,7 @@ public class GreedoLayoutSizeCalculator {
         }
     }
 
-    Size sizeForChildAtPosition(int position) {
+    public Size sizeForChildAtPosition(int position) {
         if (position >= mSizeForChildAtPosition.size()) {
             computeChildSizesUpToPosition(position);
         }
@@ -67,11 +67,25 @@ public class GreedoLayoutSizeCalculator {
         return mSizeForChildAtPosition.get(position);
     }
 
-    int getFirstChildPositionForRow(int row) {
+    public int getFirstChildPositionForRow(int row) {
         if (row >= mFirstChildPositionForRow.size()) {
             computeFirstChildPositionsUpToRow(row);
         }
         return mFirstChildPositionForRow.get(row);
+    }
+
+    public int getRowForChildPosition(int position) {
+        if (position >= mRowForChildPosition.size()) {
+            computeChildSizesUpToPosition(position);
+        }
+
+        return mRowForChildPosition.get(position);
+    }
+
+    public void reset() {
+        mSizeForChildAtPosition.clear();
+        mFirstChildPositionForRow.clear();
+        mRowForChildPosition.clear();
     }
 
     private void computeFirstChildPositionsUpToRow(int row) {
@@ -82,21 +96,7 @@ public class GreedoLayoutSizeCalculator {
         }
     }
 
-    int getRowForChildPosition(int position) {
-        if (position >= mRowForChildPosition.size()) {
-            computeChildSizesUpToPosition(position);
-        }
-
-        return mRowForChildPosition.get(position);
-    }
-
-    void reset() {
-        mSizeForChildAtPosition.clear();
-        mFirstChildPositionForRow.clear();
-        mRowForChildPosition.clear();
-    }
-
-    public void computeChildSizesUpToPosition(int lastPosition) {
+    private void computeChildSizesUpToPosition(int lastPosition) {
         if (mContentWidth == INVALID_CONTENT_WIDTH) {
             throw new RuntimeException("Invalid content width. Did you forget to set it?");
         }

--- a/greedo-layout/src/main/java/com/fivehundredpx/greedolayout/GreedoLayoutSizeCalculator.java
+++ b/greedo-layout/src/main/java/com/fivehundredpx/greedolayout/GreedoLayoutSizeCalculator.java
@@ -18,6 +18,8 @@ public class GreedoLayoutSizeCalculator {
     private static final int INVALID_CONTENT_WIDTH = -1;
     private int mContentWidth = INVALID_CONTENT_WIDTH;
 
+    private boolean mFixedHeight = false;
+
     private SizeCalculatorDelegate mSizeCalculatorDelegate;
 
     private List<Size> mSizeForChildAtPosition;
@@ -42,6 +44,13 @@ public class GreedoLayoutSizeCalculator {
     public void setMaxRowHeight(int maxRowHeight) {
         if (mMaxRowHeight != maxRowHeight) {
             mMaxRowHeight = maxRowHeight;
+            reset();
+        }
+    }
+
+    public void setFixedHeight(boolean fixedHeight) {
+        if (mFixedHeight != fixedHeight) {
+            mFixedHeight = fixedHeight;
             reset();
         }
     }

--- a/greedo-layout/src/main/java/com/fivehundredpx/greedolayout/GreedoLayoutSizeCalculator.java
+++ b/greedo-layout/src/main/java/com/fivehundredpx/greedolayout/GreedoLayoutSizeCalculator.java
@@ -18,7 +18,11 @@ public class GreedoLayoutSizeCalculator {
     private static final int INVALID_CONTENT_WIDTH = -1;
     private int mContentWidth = INVALID_CONTENT_WIDTH;
 
-    private boolean mFixedHeight = false;
+    // When in fixed height mode and the item's width is less than this percentage, don't try to
+    // fit the item, overflow it to the next row and grow the existing items.
+    private static final double VALID_ITEM_SLACK_THRESHOLD = 2.0 / 3.0;
+
+    private boolean mIsFixedHeight = false;
 
     private SizeCalculatorDelegate mSizeCalculatorDelegate;
 
@@ -49,8 +53,8 @@ public class GreedoLayoutSizeCalculator {
     }
 
     public void setFixedHeight(boolean fixedHeight) {
-        if (mFixedHeight != fixedHeight) {
-            mFixedHeight = fixedHeight;
+        if (mIsFixedHeight != fixedHeight) {
+            mIsFixedHeight = fixedHeight;
             reset();
         }
     }
@@ -72,7 +76,7 @@ public class GreedoLayoutSizeCalculator {
 
     private void computeFirstChildPositionsUpToRow(int row) {
         // TODO: Rewrite this? Looks dangerous but in reality should be fine. I'd like something
-        // less alarming though.
+        //       less alarming though.
         while (row >= mFirstChildPositionForRow.size()) {
             computeChildSizesUpToPosition(mSizeForChildAtPosition.size() + 1);
         }
@@ -105,34 +109,97 @@ public class GreedoLayoutSizeCalculator {
         int row = mRowForChildPosition.size() > 0
                 ? mRowForChildPosition.get(mRowForChildPosition.size() - 1) + 1 : 0;
 
-        double rowAspectRatio = 0.0;
-        int currentRowHeight = Integer.MAX_VALUE;
-        List<Double> aspectRatiosForRow = new ArrayList<>();
-        for (int pos = firstUncomputedChildPosition; pos < lastPosition || currentRowHeight > mMaxRowHeight; pos++) {
-            double posAspectRatio = mSizeCalculatorDelegate.aspectRatioForIndex(pos);
-            rowAspectRatio += posAspectRatio;
-            aspectRatiosForRow.add(posAspectRatio);
+        double currentRowAspectRatio = 0.0;
+        List<Double> itemAspectRatios = new ArrayList<>();
+        int currentRowHeight = mIsFixedHeight ? mMaxRowHeight : Integer.MAX_VALUE;
 
-            currentRowHeight = (int)Math.ceil(mContentWidth / rowAspectRatio);
-            if (currentRowHeight <= mMaxRowHeight) { // Row is full
-                int rowChildCount = aspectRatiosForRow.size();
+        int currentRowWidth = 0;
+        int pos = firstUncomputedChildPosition;
+        while (pos < lastPosition || (mIsFixedHeight ? currentRowWidth <= mContentWidth : currentRowHeight > mMaxRowHeight)) {
+            double posAspectRatio = mSizeCalculatorDelegate.aspectRatioForIndex(pos);
+            currentRowAspectRatio += posAspectRatio;
+            itemAspectRatios.add(posAspectRatio);
+
+            currentRowWidth = calculateWidth(currentRowHeight, currentRowAspectRatio);
+            if (!mIsFixedHeight) {
+                currentRowHeight = calculateHeight(mContentWidth, currentRowAspectRatio);
+            }
+
+            boolean isRowFull = mIsFixedHeight ? currentRowWidth > mContentWidth : currentRowHeight <= mMaxRowHeight;
+            if (isRowFull) {
+                int rowChildCount = itemAspectRatios.size();
                 mFirstChildPositionForRow.add(pos - rowChildCount + 1);
 
-                int availableSpace = mContentWidth;
-                for (Double aspectRatio : aspectRatiosForRow) {
-                    int scaledPhotoWidth = (int)Math.ceil(currentRowHeight * aspectRatio);
-                    scaledPhotoWidth = Math.min(availableSpace, scaledPhotoWidth);
+                int[] itemSlacks = new int[rowChildCount];
+                if (mIsFixedHeight) {
+                    itemSlacks = distributeRowSlack(currentRowWidth, rowChildCount, itemAspectRatios);
 
-                    mSizeForChildAtPosition.add(new Size(scaledPhotoWidth, currentRowHeight));
-                    mRowForChildPosition.add(row);
+                    if (!hasValidItemSlacks(itemSlacks, itemAspectRatios)) {
+                        int lastItemWidth = calculateWidth(currentRowHeight,
+                                itemAspectRatios.get(itemAspectRatios.size() - 1));
+                        currentRowWidth -= lastItemWidth;
+                        rowChildCount -= 1;
+                        itemAspectRatios.remove(itemAspectRatios.size() - 1);
 
-                    availableSpace = availableSpace - scaledPhotoWidth;
+                        itemSlacks = distributeRowSlack(currentRowWidth, rowChildCount, itemAspectRatios);
+                    }
                 }
 
-                aspectRatiosForRow.clear();
-                rowAspectRatio = 0.0;
+                int availableSpace = mContentWidth;
+                for (int i = 0; i < rowChildCount; i++) {
+                    int itemWidth = calculateWidth(currentRowHeight, itemAspectRatios.get(i)) - itemSlacks[i];
+                    itemWidth = Math.min(availableSpace, itemWidth);
+
+                    mSizeForChildAtPosition.add(new Size(itemWidth, currentRowHeight));
+                    mRowForChildPosition.add(row);
+
+                    availableSpace -= itemWidth;
+                }
+
+                itemAspectRatios.clear();
+                currentRowAspectRatio = 0.0;
                 row++;
             }
+
+            pos++;
         }
+    }
+
+    private int[] distributeRowSlack(int rowWidth, int rowChildCount, List<Double> itemAspectRatios) {
+        return distributeRowSlack(rowWidth - mContentWidth, rowWidth, rowChildCount, itemAspectRatios);
+    }
+
+    private int[] distributeRowSlack(int rowSlack, int rowWidth, int rowChildCount, List<Double> itemAspectRatios) {
+        int itemSlacks[] = new int[rowChildCount];
+
+        for (int i = 0; i < rowChildCount; i++) {
+            double itemWidth = mMaxRowHeight * itemAspectRatios.get(i);
+            itemSlacks[i] = (int) (rowSlack * (itemWidth / rowWidth));
+        }
+
+        return itemSlacks;
+    }
+
+    private boolean hasValidItemSlacks(int[] itemSlacks, List<Double> itemAspectRatios) {
+        for (int i = 0; i < itemSlacks.length; i++) {
+            int itemWidth = (int) (itemAspectRatios.get(i) * mMaxRowHeight);
+            if (!isValidItemSlack(itemSlacks[i], itemWidth)) {
+                return false;
+            }
+        }
+
+        return true;
+    }
+
+    private boolean isValidItemSlack(int itemSlack, int itemWidth) {
+        return (itemWidth - itemSlack) / (double) itemWidth > VALID_ITEM_SLACK_THRESHOLD;
+    }
+
+    private int calculateWidth(int itemHeight, double aspectRatio) {
+        return (int) Math.ceil(itemHeight * aspectRatio);
+    }
+
+    private int calculateHeight(int itemWidth, double aspectRatio) {
+        return (int) Math.ceil(itemWidth / aspectRatio);
     }
 }


### PR DESCRIPTION
Up until now the height of each row was dynamic based on the aspect ratios of the items within it. It was ensured to be some value less than or equal to the set max row height (via `setMaxRowHeight(int)`). This PR adds support for fixed row heights. If enabled (via `setFixedHeight(boolean)`) all heights will be fixed to the max row height.

To achieve this, some cropping on the individual items is unavoidable. To reduce that cropping however, the layout first attempts to distribute the remaining space that could not fit (the slack) amongst the items in that row, proportionally to their widths. In other words, wide items will be cropped more than narrow items. If an item in the row is cropped beyond the threshold (currently set to 2/3 of the item) the last item is pushed onto the next row and all the items become slightly wider to compensate, again proportionally. The majority of the code changes to achieve this are in the `GreedoLayoutSizeCalculator.java`.

Alongside this, I've also updated the sample project with a toggle to enable/disable fixed row heights so the effects can be seen.