### PR TITLE
Remove `static` from mMaxRowHeight

### DIFF
--- a/greedo-layout/src/main/java/com/fivehundredpx/greedolayout/GreedoLayoutSizeCalculator.java
+++ b/greedo-layout/src/main/java/com/fivehundredpx/greedolayout/GreedoLayoutSizeCalculator.java
@@ -13,7 +13,7 @@ public class GreedoLayoutSizeCalculator {
     }
 
     private static final int DEFAULT_MAX_ROW_HEIGHT = 600;
-    private static int mMaxRowHeight = DEFAULT_MAX_ROW_HEIGHT;
+    private int mMaxRowHeight = DEFAULT_MAX_ROW_HEIGHT;
 
     private static final int INVALID_CONTENT_WIDTH = -1;
     private int mContentWidth = INVALID_CONTENT_WIDTH;


### PR DESCRIPTION
This seems like an oversight; we're setting custom row height in
Onboarding and Discover users fragments and this custom height then
causes the greedo layout in profile fragment to have tiny photos
(because the row height is static).

CR: @JVillella 