### PR TITLE
Update GreedoLayoutManager.java

### DIFF
--- a/greedo-layout/src/main/java/com/fivehundredpx/greedolayout/GreedoLayoutManager.java
+++ b/greedo-layout/src/main/java/com/fivehundredpx/greedolayout/GreedoLayoutManager.java
@@ -150,6 +150,12 @@ public class GreedoLayoutManager extends RecyclerView.LayoutManager {
                         double previousTopRowHeight = sizeForChildAtPosition(
                                 mFirstVisiblePosition - 1).getHeight();
                         startTopOffset -= previousTopRowHeight;
+                        while (startTopOffset >= -dy && mFirstVisibleRow !=  0){
+                            mFirstVisibleRow--;
+                            newFirstVisiblePosition = firstChildPositionForRow(mFirstVisibleRow);
+                            startTopOffset -= sizeForChildAtPosition(newFirstVisiblePosition).getHeight();
+
+                        }
                         break;
                     case DOWN: // row may have gone off screen
                         double topRowHeight = sizeForChildAtPosition(


### PR DESCRIPTION
In case of up scrolling some of the views are not getting filled and they remain empty. When row heights are large they are not much visible, but if make row heights small (100 px, 200 px) on fast scroll up whole views are getting empty. Take this solution and problem won't exist anymore.