### PR TITLE
Defer scrollToPosition() and fix IndexOutOfBounds crash

### DIFF
--- a/greedo-layout/src/main/java/com/fivehundredpx/greedolayout/GreedoLayoutSizeCalculator.java
+++ b/greedo-layout/src/main/java/com/fivehundredpx/greedolayout/GreedoLayoutSizeCalculator.java
@@ -80,7 +80,7 @@ public class GreedoLayoutSizeCalculator {
 
     public int getRowForChildPosition(int position) {
         if (position >= mRowForChildPosition.size()) {
-            computeChildSizesUpToPosition(position);
+            computeChildSizesUpToPosition(position + 1);
         }
 
         return mRowForChildPosition.get(position);

--- a/greedo-layout/src/main/java/com/fivehundredpx/greedolayout/GreedoLayoutSizeCalculator.java
+++ b/greedo-layout/src/main/java/com/fivehundredpx/greedolayout/GreedoLayoutSizeCalculator.java
@@ -45,6 +45,10 @@ public class GreedoLayoutSizeCalculator {
         }
     }
 
+    public int getContentWidth() {
+        return mContentWidth;
+    }
+
     public void setMaxRowHeight(int maxRowHeight) {
         if (mMaxRowHeight != maxRowHeight) {
             mMaxRowHeight = maxRowHeight;

--- a/greedo-layout/src/main/java/com/fivehundredpx/greedolayout/GreedoLayoutSizeCalculator.java
+++ b/greedo-layout/src/main/java/com/fivehundredpx/greedolayout/GreedoLayoutSizeCalculator.java
@@ -80,7 +80,7 @@ public class GreedoLayoutSizeCalculator {
 
     public int getRowForChildPosition(int position) {
         if (position >= mRowForChildPosition.size()) {
-            computeChildSizesUpToPosition(position + 1);
+            computeChildSizesUpToPosition(position);
         }
 
         return mRowForChildPosition.get(position);
@@ -119,7 +119,7 @@ public class GreedoLayoutSizeCalculator {
 
         int currentRowWidth = 0;
         int pos = firstUncomputedChildPosition;
-        while (pos < lastPosition || (mIsFixedHeight ? currentRowWidth <= mContentWidth : currentRowHeight > mMaxRowHeight)) {
+        while (pos <= lastPosition || (mIsFixedHeight ? currentRowWidth <= mContentWidth : currentRowHeight > mMaxRowHeight)) {
             double posAspectRatio = mSizeCalculatorDelegate.aspectRatioForIndex(pos);
             currentRowAspectRatio += posAspectRatio;
             itemAspectRatios.add(posAspectRatio);


### PR DESCRIPTION
This PR fixes two crashes related to `scrollToPosition()` calls.

### Defer scrollToPosition() after layouting is fully finished
If scrollToPosition() is called before the postLayout pass, the
LayoutManager has no knowledge about its own sizes yet and therefore the
scroll operation cannot be completed and the safety checks in
GreedoLayoutSizeCalculator will crash on that.

So this defers the scrollToPosition() call to after the layout is
finished. Should fix #31 

### Fix index-out-of-bounds crash
With certain positions (usually those on the start of the row) this can
crash with java.lang.IndexOutOfBoundsException. The problem is that
we're checking the position with mRowForChildPosition.size() and then
computing all the child sizes *up to* the position (ie. not including
the position). This can lead to crashes as can be seen in
#20