### PR TITLE
Fix fast scroll up blank screen issue

### DIFF
--- a/greedo-layout/src/main/java/com/fivehundredpx/greedolayout/GreedoLayoutManager.java
+++ b/greedo-layout/src/main/java/com/fivehundredpx/greedolayout/GreedoLayoutManager.java
@@ -192,6 +192,16 @@ public class GreedoLayoutManager extends RecyclerView.LayoutManager {
                 detachView(cachedView);
             }
         }
+        //Check if it is scrolled too fast and if so find the row that should be displayed first
+        //If startTopOffset is greater than zero than that means we are trying to fill the screen
+        //somewhere below the top part.
+        if (startTopOffset > 0 && direction == Direction.UP) {
+            while (startTopOffset > 0 && mFirstVisibleRow != 0) {
+                mFirstVisibleRow--;
+                newFirstVisiblePosition = firstChildPositionForRow(mFirstVisibleRow);
+                startTopOffset -= sizeForChildAtPosition(newFirstVisiblePosition).getHeight();
+            }
+        }
 
         mFirstVisiblePosition = newFirstVisiblePosition;
 
@@ -378,8 +388,9 @@ public class GreedoLayoutManager extends RecyclerView.LayoutManager {
         if (getChildCount() == 0 || dy == 0) {
             return 0;
         }
-
+        //Take top measurements from the top-left child
         final View topLeftView = getChildAt(0);
+        //Take bottom measurements from the bottom-right child.
         final View bottomRightView = getChildAt(getChildCount() - 1);
         int pixelsFilled = getContentHeight();
         // TODO: Split into methods, or a switch case?


### PR DESCRIPTION
The `GreedoLayoutManager` was not able to fill the screen with views on fast scroll, because the layout manager was assuming that each call to `scrollVerticallyBy()`, the `mFirstVisibleRow` value  should increase/decrease at most by one, but if you scroll too fast and/or if you are processing some other tasks on the main thread than the calls to the `scrollVerticallyBy()` might delay and in that case the `mFirstVisibleRow` might be wrong and it could cause the layout manager to stop filling the screen with views (Because it checks the position of the first visible object on the `mFirstVisibleRow` and if that position is greater than the screen height than it stops filling the screen)

- With this PR the `GreedoLayoutManager` checks the position of the first visible item and if it is greater than zero than it means that the `mFirstVisibleRow` should be updated and the `GreedoLayoutManager` loops through the rows to find the first visible row and updates the `mFirstVisibleRow`