### PR TITLE
Migrate to AndroidX + make RecyclerView.canScrollVerticall(-1) work

### DIFF
--- a/greedo-layout-sample/build.gradle
+++ b/greedo-layout-sample/build.gradle
@@ -5,12 +5,12 @@ repositories {
 }
 
 android {
-    compileSdkVersion 26
+    compileSdkVersion 28
     buildToolsVersion "28.0.3"
 
     defaultConfig {
         minSdkVersion 15
-        targetSdkVersion 26
+        targetSdkVersion 28
         versionCode 1
         versionName "1.0"
     }
@@ -25,8 +25,8 @@ android {
 dependencies {
     implementation fileTree(dir: 'libs', include: ['*.jar'])
     implementation project(':greedo-layout')
-    implementation 'com.android.support:appcompat-v7:26.1.0'
-    implementation 'com.android.support:recyclerview-v7:26.1.0'
+    implementation 'androidx.appcompat:appcompat:1.1.0'
+    implementation 'androidx.recyclerview:recyclerview:1.1.0'
     implementation 'com.squareup.okhttp:okhttp:2.7.2'
     implementation 'com.squareup.picasso:picasso:2.5.2'
 }

--- a/greedo-layout-sample/src/main/java/com/fivehundredpx/greedo_layout_sample/Constants.java
+++ b/greedo-layout-sample/src/main/java/com/fivehundredpx/greedo_layout_sample/Constants.java
@@ -1,6 +1,6 @@
 package com.fivehundredpx.greedo_layout_sample;
 
-import android.support.annotation.DrawableRes;
+import androidx.annotation.DrawableRes;
 
 /**
  * Created by Julian Villella on 16-02-24.

--- a/greedo-layout-sample/src/main/java/com/fivehundredpx/greedo_layout_sample/PhotosAdapter.java
+++ b/greedo-layout-sample/src/main/java/com/fivehundredpx/greedo_layout_sample/PhotosAdapter.java
@@ -2,9 +2,10 @@ package com.fivehundredpx.greedo_layout_sample;
 
 import android.content.Context;
 import android.graphics.BitmapFactory;
-import android.support.v7.widget.RecyclerView;
 import android.view.ViewGroup;
 import android.widget.ImageView;
+
+import androidx.recyclerview.widget.RecyclerView;
 
 import com.fivehundredpx.greedolayout.GreedoLayoutSizeCalculator.SizeCalculatorDelegate;
 import com.squareup.picasso.Picasso;

--- a/greedo-layout-sample/src/main/java/com/fivehundredpx/greedo_layout_sample/SampleActivity.java
+++ b/greedo-layout-sample/src/main/java/com/fivehundredpx/greedo_layout_sample/SampleActivity.java
@@ -2,12 +2,12 @@ package com.fivehundredpx.greedo_layout_sample;
 
 import android.os.Build;
 import android.os.Bundle;
-import android.support.v7.widget.RecyclerView;
 import android.view.View;
 import android.view.WindowManager;
 import android.widget.ToggleButton;
 
 import androidx.appcompat.app.AppCompatActivity;
+import androidx.recyclerview.widget.RecyclerView;
 
 import com.fivehundredpx.greedolayout.GreedoLayoutManager;
 import com.fivehundredpx.greedolayout.GreedoSpacingItemDecoration;

--- a/greedo-layout-sample/src/main/java/com/fivehundredpx/greedo_layout_sample/SampleActivity.java
+++ b/greedo-layout-sample/src/main/java/com/fivehundredpx/greedo_layout_sample/SampleActivity.java
@@ -2,13 +2,12 @@ package com.fivehundredpx.greedo_layout_sample;
 
 import android.os.Build;
 import android.os.Bundle;
-import android.support.v7.app.AppCompatActivity;
 import android.support.v7.widget.RecyclerView;
-import android.util.DisplayMetrics;
 import android.view.View;
-import android.view.Window;
 import android.view.WindowManager;
 import android.widget.ToggleButton;
+
+import androidx.appcompat.app.AppCompatActivity;
 
 import com.fivehundredpx.greedolayout.GreedoLayoutManager;
 import com.fivehundredpx.greedolayout.GreedoSpacingItemDecoration;

--- a/greedo-layout-sample/src/main/res/layout/activity_sample.xml
+++ b/greedo-layout-sample/src/main/res/layout/activity_sample.xml
@@ -6,7 +6,7 @@
     android:layout_height="match_parent"
     tools:context="com.fivehundredpx.greedo_layout_sample.SampleActivity">
 
-    <android.support.v7.widget.RecyclerView
+    <androidx.recyclerview.widget.RecyclerView
         android:id="@+id/recycler_view"
         android:layout_width="match_parent"
         android:layout_height="match_parent" />

--- a/greedo-layout/build.gradle
+++ b/greedo-layout/build.gradle
@@ -6,12 +6,12 @@ repositories {
 }
 
 android {
-    compileSdkVersion 26
+    compileSdkVersion 28
     buildToolsVersion '28.0.3'
 
     defaultConfig {
         minSdkVersion 15
-        targetSdkVersion 26
+        targetSdkVersion 28
         versionCode 1
         versionName "1.3.0"
     }

--- a/greedo-layout/build.gradle
+++ b/greedo-layout/build.gradle
@@ -25,8 +25,8 @@ android {
 
 dependencies {
     implementation fileTree(dir: 'libs', include: ['*.jar'])
-    implementation 'com.android.support:appcompat-v7:26.1.0'
-    implementation 'com.android.support:recyclerview-v7:26.1.0'
+    implementation 'androidx.appcompat:appcompat:1.1.0'
+    implementation 'androidx.recyclerview:recyclerview:1.1.0'
 }
 
 uploadArchives {

--- a/greedo-layout/src/main/java/com/fivehundredpx/greedolayout/GreedoLayoutManager.java
+++ b/greedo-layout/src/main/java/com/fivehundredpx/greedolayout/GreedoLayoutManager.java
@@ -1,10 +1,12 @@
 package com.fivehundredpx.greedolayout;
 
-import android.support.v7.widget.RecyclerView;
 import android.util.Log;
 import android.util.SparseArray;
 import android.view.View;
 import android.view.ViewGroup;
+
+import androidx.annotation.NonNull;
+import androidx.recyclerview.widget.RecyclerView;
 
 import com.fivehundredpx.greedolayout.GreedoLayoutSizeCalculator.SizeCalculatorDelegate;
 

--- a/greedo-layout/src/main/java/com/fivehundredpx/greedolayout/GreedoLayoutManager.java
+++ b/greedo-layout/src/main/java/com/fivehundredpx/greedolayout/GreedoLayoutManager.java
@@ -376,6 +376,18 @@ public class GreedoLayoutManager extends RecyclerView.LayoutManager {
     }
 
     @Override
+    public int computeVerticalScrollOffset(RecyclerView.State state) {
+        View topLeftView = getChildAt(0);
+        return topLeftView == null ? 0 : Math.abs(getDecoratedTop(topLeftView));
+    }
+
+    @Override
+    public int computeVerticalScrollRange(@NonNull RecyclerView.State state) {
+        View bottomRightView = getChildAt(getChildCount() - 1);
+        return bottomRightView == null ? 0 : getDecoratedBottom(bottomRightView);
+    }
+
+    @Override
     public int scrollVerticallyBy(int dy, RecyclerView.Recycler recycler, RecyclerView.State state) {
         if (getChildCount() == 0 || dy == 0) {
             return 0;

--- a/greedo-layout/src/main/java/com/fivehundredpx/greedolayout/GreedoSpacingItemDecoration.java
+++ b/greedo-layout/src/main/java/com/fivehundredpx/greedolayout/GreedoSpacingItemDecoration.java
@@ -1,8 +1,9 @@
 package com.fivehundredpx.greedolayout;
 
 import android.graphics.Rect;
-import android.support.v7.widget.RecyclerView;
 import android.view.View;
+
+import androidx.recyclerview.widget.RecyclerView;
 
 /**
  * Created by Julian Villella on 15-07-30.


### PR DESCRIPTION
This PR migrates the whole project to AndroidX
and implements two scrolling offset calculations
functions - `computeVerticalScrollOffset(..)` and
`computeVerticalScrollRange(..)` which in turn
makes `RecyclerView.canScrollVerticall(-1)` work.