### PR TITLE
Fix GreedoLayoutSizeCalculator FixHeight mode pos index error

### DIFF
--- a/greedo-layout/src/main/java/com/fivehundredpx/greedolayout/GreedoLayoutSizeCalculator.java
+++ b/greedo-layout/src/main/java/com/fivehundredpx/greedolayout/GreedoLayoutSizeCalculator.java
@@ -161,6 +161,7 @@ public class GreedoLayoutSizeCalculator {
                                 itemAspectRatios.get(itemAspectRatios.size() - 1));
                         currentRowWidth -= lastItemWidth;
                         rowChildCount -= 1;
+                        --pos;
                         itemAspectRatios.remove(itemAspectRatios.size() - 1);
 
                         itemSlacks = distributeRowSlack(currentRowWidth, rowChildCount, itemAspectRatios);


### PR DESCRIPTION

### What's in this PR?
- Set mIsFixedHeight in GreedoLayoutSizeCalculator to true, When `hasValidItemSlacks` returns false, then you need to reduce a child, so `pos` also needs to be reduced by 1.