### PR TITLE
Fixed height bug fix

### DIFF
--- a/greedo-layout/src/main/java/com/fivehundredpx/greedolayout/GreedoLayoutSizeCalculator.java
+++ b/greedo-layout/src/main/java/com/fivehundredpx/greedolayout/GreedoLayoutSizeCalculator.java
@@ -156,7 +156,7 @@ public class GreedoLayoutSizeCalculator {
                 if (mIsFixedHeight) {
                     itemSlacks = distributeRowSlack(currentRowWidth, rowChildCount, itemAspectRatios);
 
-                    if (!hasValidItemSlacks(itemSlacks, itemAspectRatios)) {
+                    if (rowChildCount > 1 && !hasValidItemSlacks(itemSlacks, itemAspectRatios)) {
                         int lastItemWidth = calculateWidth(currentRowHeight,
                                 itemAspectRatios.get(itemAspectRatios.size() - 1));
                         currentRowWidth -= lastItemWidth;


### PR DESCRIPTION


### What's in this PR?
- `GreedoLayoutSizeCalculator` has a special situation in `FixedHeight` mode. When a photo is a horizontal image with a large aspect ratio, `hasValidItemSlacks` will return false. After `--pos`, the while statement will finally execute `pos++`, `computeChildSizesUpToPosition` method The `while` in will continue to loop, causing the app to crash after OOM.
![Screenshot_1599130559](https://user-images.githubusercontent.com/16127348/92110507-6ab60f00-ee1d-11ea-87fe-e920eb71ab9b.png)
![Screenshot_1599129828](https://user-images.githubusercontent.com/16127348/92110518-6db0ff80-ee1d-11ea-9e05-01cc01b044f8.png)

